### PR TITLE
Fix REST-API / Swagger Error:

### DIFF
--- a/Api/Data/ProductLabelInterface.php
+++ b/Api/Data/ProductLabelInterface.php
@@ -170,7 +170,7 @@ interface ProductLabelInterface
     /**
      * Get display_on
      *
-     * @return array
+     * @return mixed[]
      */
     public function getDisplayOn();
 


### PR DESCRIPTION
The "array" class doesn't exist and the namespace must be specified...