### PR TITLE
Update ProductLabelInterface.php

### DIFF
--- a/Api/Data/ProductLabelInterface.php
+++ b/Api/Data/ProductLabelInterface.php
@@ -170,7 +170,7 @@ interface ProductLabelInterface
     /**
      * Get display_on
      *
-     * @return array
+     * @return mixed
      */
     public function getDisplayOn();
 


### PR DESCRIPTION
{"message":"The \"array\" class doesn't exist and the namespace must be specified. Verify and try again.","trace":"#0 /vendor\/magento\/framework\/Reflection\/TypeProcessor.php(219): Magento\\Framework\\Reflection\\TypeProcessor->register('array')
...

Resolve the error in 2.3.x version.
