### PR TITLE
Feature - Add beginning and ending dates to product label

### DIFF
--- a/Api/Data/ProductLabelInterface.php
+++ b/Api/Data/ProductLabelInterface.php
@@ -58,6 +58,16 @@ interface ProductLabelInterface
     const OPTION_ID = 'option_id';
 
     /**
+     * Constant for field from_date
+     */
+    const FROM_DATE = 'from_date';
+
+    /**
+     * Constant for field to_date
+     */
+    const TO_DATE = 'to_date';
+
+    /**
      * Constant for field image
      */
     const PRODUCTLABEL_IMAGE = 'image';
@@ -147,6 +157,20 @@ interface ProductLabelInterface
     public function getOptionId(): int;
 
     /**
+     * Get from date
+     *
+     * @return string
+     */
+    public function getFromDate(): string;
+
+    /**
+     * Get to date
+     *
+     * @return string
+     */
+    public function getToDate(): string;
+
+    /**
      * Get image
      *
      * @return string
@@ -225,6 +249,24 @@ interface ProductLabelInterface
      * @return ProductLabelInterface
      */
     public function setOptionId(int $value);
+
+    /**
+     * Set from date
+     *
+     * @param string $value From Date
+     *
+     * @return ProductLabelInterface
+     */
+    public function setFromDate(string $value);
+
+    /**
+     * Set to date
+     *
+     * @param string $value To Date
+     *
+     * @return ProductLabelInterface
+     */
+    public function setToDate(string $value);
 
     /**
      * Set Image.

--- a/Block/ProductLabel/ProductLabel.php
+++ b/Block/ProductLabel/ProductLabel.php
@@ -56,6 +56,11 @@ class ProductLabel extends Template implements IdentityInterface
     private $cache;
 
     /**
+     * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
+     */
+    private $timezoneInterface;
+
+    /**
      * @var \Magento\Store\Model\StoreManagerInterface
      */
     private $storeManager;
@@ -63,12 +68,13 @@ class ProductLabel extends Template implements IdentityInterface
     /**
      * ProductLabel constructor.
      *
-     * @param \Magento\Backend\Block\Template\Context    $context                       Block context
-     * @param Registry                                   $registry                      Registry
-     * @param \Smile\ProductLabel\Model\ImageLabel\Image $imageHelper                   Image Helper
-     * @param ProductLabelCollectionFactory              $productLabelCollectionFactory Product Label Collection Factory
-     * @param \Magento\Framework\App\CacheInterface      $cache                         Cache Interface
-     * @param array                                      $data                          Block data
+     * @param \Magento\Backend\Block\Template\Context              $context                       Block context
+     * @param Registry                                             $registry                      Registry
+     * @param \Smile\ProductLabel\Model\ImageLabel\Image           $imageHelper                   Image Helper
+     * @param ProductLabelCollectionFactory                        $productLabelCollectionFactory Product Label Collection Factory
+     * @param \Magento\Framework\App\CacheInterface                $cache                         Cache Interface
+     * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $timezoneInterface             Timezone Interface
+     * @param array                                                $data                          Block data
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
@@ -76,6 +82,7 @@ class ProductLabel extends Template implements IdentityInterface
         \Smile\ProductLabel\Model\ImageLabel\Image $imageHelper,
         ProductLabelCollectionFactory $productLabelCollectionFactory,
         \Magento\Framework\App\CacheInterface $cache,
+        \Magento\Framework\Stdlib\DateTime\TimezoneInterface $timezoneInterface,
         array $data = []
     ) {
         $this->registry                      = $registry;
@@ -83,6 +90,7 @@ class ProductLabel extends Template implements IdentityInterface
         $this->productLabelCollectionFactory = $productLabelCollectionFactory;
         $this->cache                         = $cache;
         $this->storeManager                  = $context->getStoreManager();
+        $this->timezoneInterface             = $timezoneInterface;
 
         parent::__construct($context, $data);
     }
@@ -186,6 +194,12 @@ class ProductLabel extends Template implements IdentityInterface
         $attributesProduct = $this->getAttributesOfCurrentProduct();
 
         foreach ($productLabelList as $productLabel) {
+            if (
+                $productLabel['from_date'] > $this->timezoneInterface->date()->format('Y-m-d') ||
+                $productLabel['to_date'] < $this->timezoneInterface->date()->format('Y-m-d')
+            ) {
+                continue;
+            }
             $attributeIdLabel = $productLabel['attribute_id'];
             $optionIdLabel    = $productLabel['option_id'];
             foreach ($attributesProduct as $attribute) {

--- a/Model/ProductLabel.php
+++ b/Model/ProductLabel.php
@@ -60,6 +60,11 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
     protected $mediaDirectory;
 
     /**
+     * @var \Magento\Framework\Stdlib\DateTime\TimezoneInterface
+     */
+    protected $timezoneInterface;
+
+    /**
      * @var string
      */
     protected $_cacheTag = self::CACHE_TAG;
@@ -73,6 +78,7 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
      * @param \Magento\Framework\Filesystem                                $filesystem         FileSystem Helper
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource           Resource
      * @param \Magento\Framework\Data\Collection\AbstractDb|null           $resourceCollection Resource Collection
+     * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface         $timezoneInterface  Timezone Interface
      * @param array                                                        $data               Object Data
      */
     public function __construct(
@@ -82,10 +88,12 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        \Magento\Framework\Stdlib\DateTime\TimezoneInterface $timezoneInterface,
         array $data = []
     ) {
         $this->storeManager   = $storeManager;
         $this->mediaDirectory = $filesystem->getDirectoryWrite(\Magento\Framework\App\Filesystem\DirectoryList::MEDIA);
+        $this->timezoneInterface = $timezoneInterface;
         parent::__construct(
             $context,
             $registry,
@@ -168,6 +176,26 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
     public function getOptionId(): int
     {
         return (int) $this->getData(self::OPTION_ID);
+    }
+
+    /**
+     * Get field: from_date
+     *
+     * @return string
+     */
+    public function getFromDate(): string
+    {
+        return (string) $this->getData(self::FROM_DATE);
+    }
+
+    /**
+     * Get field: to_date
+     *
+     * @return string
+     */
+    public function getToDate(): string
+    {
+        return (string) $this->getData(self::TO_DATE);
     }
 
     /**
@@ -287,6 +315,30 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
     }
 
     /**
+     * Set field: from_date.
+     *
+     * @param string $value Field value
+     *
+     * @return $this
+     */
+    public function setFromDate(string $value)
+    {
+        return (string) $this->setData(self::FROM_DATE, $value);
+    }
+
+    /**
+     * Set field: to_date.
+     *
+     * @param string $value Field value
+     *
+     * @return $this
+     */
+    public function setToDate(string $value)
+    {
+        return (string) $this->setData(self::TO_DATE, $value);
+    }
+
+    /**
      * Set field: image.
      *
      * @param string $value Field value
@@ -355,6 +407,8 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
         $this->setData(self::PRODUCTLABEL_NAME, (string) $values['name']);
         $this->setData(self::ATTRIBUTE_ID, (int) $values['attribute_id']);
         $this->setData(self::OPTION_ID, (int) $values['option_id']);
+        $this->setData(self::FROM_DATE, (string) $this->timezoneInterface->date($values['from_date'])->format('Y-m-d H:i:s'));
+        $this->setData(self::TO_DATE, (string) $this->timezoneInterface->date($values['to_date'])->format('Y-m-d H:i:s'));
         $this->setData(self::PRODUCTLABEL_IMAGE, $values['image'][0]['name']);
         $this->setData(self::PRODUCTLABEL_POSITION_CATEGORY_LIST, (string) $values['position_category_list']);
         $this->setData(self::PRODUCTLABEL_POSITION_PRODUCT_VIEW, (string) $values['position_product_view']);

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -23,6 +23,8 @@
         <column xsi:type="smallint" name="attribute_id" padding="5" unsigned="true" nullable="false" identity="false" default="0"
                 comment="Attribute ID"/>
         <column xsi:type="int" name="option_id" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Option Id"/>
+        <column xsi:type="date" name="from_date" nullable="true" comment="From Date"/>
+        <column xsi:type="date" name="to_date" nullable="true" comment="To Date"/>
         <column xsi:type="blob" name="image" nullable="true" comment="Image of Attribute or Option of Attribute"/>
         <column xsi:type="varchar" name="position_category_list" nullable="true" comment="Position of Image on Category List"/>
         <column xsi:type="varchar" name="position_product_view" nullable="true" comment="Position of Image on Product View"/>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -21,3 +21,5 @@
 "Alternative text for this label","Alternative text for this label"
 "All Store Views","All Store Views"
 "Store View","Store View"
+"From Date","From Date"
+"To Date","To Date"

--- a/i18n/fr_FR.csv
+++ b/i18n/fr_FR.csv
@@ -25,3 +25,5 @@
 "Alternative text for this label","Texte alternatif du label"
 "All Store Views","Toutes les vues magasin"
 "Store View","Vue magasin"
+"From Date","De la date"
+"To Date","À la date"

--- a/view/adminhtml/ui_component/smile_productlabel_productlabel_form.xml
+++ b/view/adminhtml/ui_component/smile_productlabel_productlabel_form.xml
@@ -237,7 +237,43 @@
             </formElements>
         </field>
 
-        <field name="image" formElement="imageUploader" sortOrder="50">
+        <field name="from_date" formElement="date" sortOrder="50">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">from_date</item>
+                </item>
+            </argument>
+            <settings>
+                <validation>
+                    <rule name="validate-date" xsi:type="boolean">true</rule>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+                <dataType>text</dataType>
+                <label translate="true">Form Date</label>
+                <visible>true</visible>
+                <dataScope>from_date</dataScope>
+            </settings>
+        </field>
+
+        <field name="to_date" formElement="date" sortOrder="55">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">to_date</item>
+                </item>
+            </argument>
+            <settings>
+                <validation>
+                    <rule name="validate-date" xsi:type="boolean">true</rule>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+                <dataType>text</dataType>
+                <label translate="true">To Date</label>
+                <visible>true</visible>
+                <dataScope>to_date</dataScope>
+            </settings>
+        </field>
+
+        <field name="image" formElement="imageUploader" sortOrder="60">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">productlabel</item>
@@ -245,6 +281,7 @@
             </argument>
             <settings>
                 <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
                     <rule name="required-entry" xsi:type="boolean">true</rule>
                 </validation>
                 <elementTmpl>ui/form/element/uploader/image</elementTmpl>
@@ -270,7 +307,7 @@
             </formElements>
         </field>
 
-        <field name="position_category_list" formElement="select" sortOrder="60">
+        <field name="position_category_list" formElement="select" sortOrder="70">
             <argument name="data" xsi:type="array">
                 <item name="options" xsi:type="object">Smile\ProductLabel\Ui\Component\Source\Location\Options</item>
                 <item name="config" xsi:type="array">
@@ -290,7 +327,7 @@
             </settings>
         </field>
 
-        <field name="position_product_view" formElement="select" sortOrder="70">
+        <field name="position_product_view" formElement="select" sortOrder="80">
             <argument name="data" xsi:type="array">
                 <item name="options" xsi:type="object">Smile\ProductLabel\Ui\Component\Source\Location\Options</item>
                 <item name="config" xsi:type="array">
@@ -310,7 +347,7 @@
             </settings>
         </field>
 
-        <field name="display_on" formElement="multiselect" sortOrder="80">
+        <field name="display_on" formElement="multiselect" sortOrder="90">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">productlabel</item>
@@ -334,7 +371,7 @@
             </formElements>
         </field>
 
-        <field name="alt" formElement="input" sortOrder="90">
+        <field name="alt" formElement="input" sortOrder="100">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">alt</item>

--- a/view/adminhtml/ui_component/smile_productlabel_productlabel_listing.xml
+++ b/view/adminhtml/ui_component/smile_productlabel_productlabel_listing.xml
@@ -191,7 +191,27 @@
             </settings>
         </column>
 
-        <column name="is_active" sortOrder="60" component="Magento_Ui/js/grid/columns/select">
+        <column name="from_date" sortOrder="60" class="Magento\Ui\Component\Listing\Columns\Date"
+                component="Magento_Ui/js/grid/columns/date">
+            <settings>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <dataType>date</dataType>
+                <label translate="true">From Date</label>
+            </settings>
+        </column>
+
+        <column name="to_date" sortOrder="65" class="Magento\Ui\Component\Listing\Columns\Date"
+                component="Magento_Ui/js/grid/columns/date">
+            <settings>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <dataType>date</dataType>
+                <label translate="true">To Date</label>
+            </settings>
+        </column>
+
+        <column name="is_active" sortOrder="70" component="Magento_Ui/js/grid/columns/select">
             <settings>
                 <options>
                     <option name="active" xsi:type="array">
@@ -212,7 +232,7 @@
             </settings>
         </column>
 
-        <column name="store_id" class="Magento\Store\Ui\Component\Listing\Column\Store" sortOrder="65">
+        <column name="store_id" class="Magento\Store\Ui\Component\Listing\Column\Store" sortOrder="80">
             <settings>
                 <label translate="true">Store View</label>
                 <bodyTmpl>ui/grid/cells/html</bodyTmpl>
@@ -220,7 +240,7 @@
             </settings>
         </column>
 
-        <actionsColumn sortOrder="70" name="actions" class="Smile\ProductLabel\Ui\Component\Listing\Column\AttributeActions">
+        <actionsColumn sortOrder="90" name="actions" class="Smile\ProductLabel\Ui\Component\Listing\Column\AttributeActions">
             <settings>
                 <indexField>product_label_id</indexField>
             </settings>


### PR DESCRIPTION
In this feature, we wanted to add the possibility of setting a begining date and ending date to show a product label.

To do so, we added two date fields in the database and did the same for the back office. We linked them together and added a simple condition in order to check if the product label should be shown in the storefront.

![image](https://user-images.githubusercontent.com/59695834/94021064-e6b7cd00-fdb3-11ea-9a09-bc9ef98c8115.png)
![image](https://user-images.githubusercontent.com/59695834/94021268-1f57a680-fdb4-11ea-86ae-fd487d5a9f69.png)
