### PR TITLE
Fix for php8.1 conversation to explode function

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -86,7 +86,7 @@ class Data extends AbstractHelper
     {
         $plabelIds = $product->getSmileProductLabelIds();
         if (!is_array($plabelIds)) {
-            $plabelIds = explode(',', $plabelIds);
+            $plabelIds = explode(',', $plabelIds ?? '');
         }
 
         foreach ($plabelIds as $key => $value) {


### PR DESCRIPTION
**Description (*)**

Fix compatibility with php8.1 and magento2.4.4. Error during save product "Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/html/vendor/smile/module-product-label/Helper/Data.php on line 89"

**Related Pull Requests**

**Fixed Issues (if relevant)**

**Manual testing scenarios (*)**

1. Create product label with any attributes
2. Save product with this attribute

**Questions or comments**