### PR TITLE
Fix typing in ProductLabel Block

### DIFF
--- a/Block/ProductLabel/ProductLabel.php
+++ b/Block/ProductLabel/ProductLabel.php
@@ -27,7 +27,7 @@ class ProductLabel extends Template implements IdentityInterface
 
     protected Image $imageHelper;
 
-    protected ProductInterface $product;
+    protected ProductInterface|null $product;
 
     private CacheInterface $cache;
 
@@ -210,8 +210,12 @@ class ProductLabel extends Template implements IdentityInterface
     {
         $identities = [];
 
-        /** @var IdentityInterface $product */
+        /** @var IdentityInterface|null $product */
         $product = $this->getProduct();
+
+        if ($product === null) {
+            return [\Smile\ProductLabel\Model\ProductLabel::CACHE_TAG];
+        }
 
         return array_merge(
             $identities,


### PR DESCRIPTION
As the file declare as strict, `\Smile\ProductLabel\Block\ProductLabel\ProductLabel::getProduct` can't set `$this->product` as `null`, but on empty category, `$this->registry->registry('current_product')` can be `null`.
This cause PHP to raise a fatal error.

This PR fix the issue by allowing `$this->product` to be `null`