### PR TITLE
Feature - Add beginning and ending dates to product label

### DIFF
--- a/Api/Data/ProductLabelInterface.php
+++ b/Api/Data/ProductLabelInterface.php
@@ -45,6 +45,16 @@ interface ProductLabelInterface
     public const OPTION_ID = 'option_id';
 
     /**
+     * Constant for field from_date
+     */
+    const FROM_DATE = 'from_date';
+
+    /**
+     * Constant for field to_date
+     */
+    const TO_DATE = 'to_date';
+
+    /**
      * Constant for field image
      */
     public const PRODUCTLABEL_IMAGE = 'image';
@@ -134,6 +144,20 @@ interface ProductLabelInterface
     public function getOptionId(): int;
 
     /**
+     * Get from date
+     *
+     * @return string
+     */
+    public function getFromDate(): string;
+
+    /**
+     * Get to date
+     *
+     * @return string
+     */
+    public function getToDate(): string;
+
+    /**
      * Get image
      *
      * @return string
@@ -207,6 +231,24 @@ interface ProductLabelInterface
      * @return ProductLabelInterface
      */
     public function setOptionId(int $value): ProductLabelInterface;
+
+    /**
+     * Set from date
+     *
+     * @param string $value From Date
+     *
+     * @return ProductLabelInterface
+     */
+    public function setFromDate(string $value);
+
+    /**
+     * Set to date
+     *
+     * @param string $value To Date
+     *
+     * @return ProductLabelInterface
+     */
+    public function setToDate(string $value);
 
     /**
      * Set Image.

--- a/Block/ProductLabel/ProductLabel.php
+++ b/Block/ProductLabel/ProductLabel.php
@@ -10,6 +10,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Registry;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Framework\View\Element\Template;
 use Magento\Store\Model\StoreManagerInterface;
 use Smile\ProductLabel\Api\Data\ProductLabelInterface;
@@ -42,6 +43,7 @@ class ProductLabel extends Template implements IdentityInterface
      * @param ProductLabelCollectionFactory $productLabelCollectionFactory Product Label Collection Factory
      * @param CacheInterface $cache Cache Interface
      * @param ?ProductInterface $product Product interface
+     * @param TimezoneInterface $timezoneInterface Timezone Interface
      * @param array $data Block data
      */
     public function __construct(
@@ -51,6 +53,7 @@ class ProductLabel extends Template implements IdentityInterface
         ProductLabelCollectionFactory $productLabelCollectionFactory,
         CacheInterface $cache,
         ?ProductInterface $product,
+        TimezoneInterface $timezoneInterface,
         array $data = []
     ) {
         $this->registry = $registry;
@@ -59,6 +62,7 @@ class ProductLabel extends Template implements IdentityInterface
         $this->cache = $cache;
         $this->storeManager = $context->getStoreManager();
         $this->product = $product;
+        $this->timezoneInterface = $timezoneInterface;
         parent::__construct($context, $data);
     }
 
@@ -168,6 +172,12 @@ class ProductLabel extends Template implements IdentityInterface
         $attributesProduct = $this->getAttributesOfCurrentProduct();
 
         foreach ($productLabelList as $productLabel) {
+            if (
+                $productLabel['from_date'] > $this->timezoneInterface->date()->format('Y-m-d') ||
+                $productLabel['to_date'] < $this->timezoneInterface->date()->format('Y-m-d')
+            ) {
+                continue;
+            }
             $attributeIdLabel = $productLabel['attribute_id'];
             $optionIdLabel    = $productLabel['option_id'];
             foreach ($attributesProduct as $attribute) {

--- a/Model/ProductLabel.php
+++ b/Model/ProductLabel.php
@@ -9,6 +9,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\WriteInterface;
@@ -58,6 +59,7 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
      * @param AbstractResource|null $resource Resource
      * @param AbstractDb|null $resourceCollection Resource Collection
      * @param ImageUploader $imageUploader Image uploader
+     * @param TimezoneInterface $timezoneInterface  Timezone Interface
      * @param array $data Object Data
      */
     public function __construct(
@@ -65,6 +67,7 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
         Registry              $registry,
         StoreManagerInterface $storeManager,
         Filesystem            $filesystem,
+        TimezoneInterface     $timezoneInterface,
         ?AbstractResource     $resource = null,
         ?AbstractDb           $resourceCollection = null,
         ?ImageUploader        $imageUploader = null,
@@ -73,6 +76,7 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
         $this->storeManager = $storeManager;
         $this->mediaDirectory = $filesystem->getDirectoryWrite(DirectoryList::MEDIA);
         $this->imageUploader = $imageUploader;
+        $this->timezoneInterface = $timezoneInterface;
         parent::__construct(
             $context,
             $registry,
@@ -146,6 +150,22 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
     public function getOptionId(): int
     {
         return (int) $this->getData(self::OPTION_ID);
+    }
+
+    /**
+     * Get field: from_date
+     */
+    public function getFromDate(): string
+    {
+        return (string) $this->getData(self::FROM_DATE);
+    }
+
+    /**
+     * Get field: to_date
+     */
+    public function getToDate(): string
+    {
+        return (string) $this->getData(self::TO_DATE);
     }
 
     /**
@@ -246,6 +266,26 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
     }
 
     /**
+     * Set field: from_date.
+     *
+     * @param string $value Field value
+     */
+    public function setFromDate(string $value): ProductLabelInterface
+    {
+        return (string) $this->setData(self::FROM_DATE, $value);
+    }
+
+    /**
+     * Set field: to_date.
+     *
+     * @param string $value Field value
+     */
+    public function setToDate(string $value): ProductLabelInterface
+    {
+        return (string) $this->setData(self::TO_DATE, $value);
+    }
+
+    /**
      * Set Image.
      *
      * @param string $value The product label Image
@@ -307,6 +347,8 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
         $this->setData(self::PRODUCTLABEL_NAME, (string) $values['name']);
         $this->setData(self::ATTRIBUTE_ID, (int) $values['attribute_id']);
         $this->setData(self::OPTION_ID, (int) $values['option_id']);
+        $this->setData(self::FROM_DATE, (string) $this->timezoneInterface->date($values['from_date'])->format('Y-m-d H:i:s'));
+        $this->setData(self::TO_DATE, (string) $this->timezoneInterface->date($values['to_date'])->format('Y-m-d H:i:s'));
         $this->setData(self::PRODUCTLABEL_IMAGE, $values['image'][0]['name']);
         $this->setData(self::PRODUCTLABEL_POSITION_CATEGORY_LIST, (string) $values['position_category_list']);
         $this->setData(self::PRODUCTLABEL_POSITION_PRODUCT_VIEW, (string) $values['position_product_view']);

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -9,6 +9,8 @@
         <column xsi:type="smallint" name="attribute_id" padding="5" unsigned="true" nullable="false" identity="false" default="0"
                 comment="Attribute ID"/>
         <column xsi:type="int" name="option_id" padding="10" unsigned="true" nullable="false" identity="false" default="0" comment="Option Id"/>
+        <column xsi:type="date" name="from_date" nullable="true" comment="From Date"/>
+        <column xsi:type="date" name="to_date" nullable="true" comment="To Date"/>
         <column xsi:type="blob" name="image" nullable="true" comment="Image of Attribute or Option of Attribute"/>
         <column xsi:type="varchar" name="position_category_list" nullable="true" comment="Position of Image on Category List"/>
         <column xsi:type="varchar" name="position_product_view" nullable="true" comment="Position of Image on Product View"/>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -21,3 +21,5 @@
 "Alternative text for this label","Alternative text for this label"
 "All Store Views","All Store Views"
 "Store View","Store View"
+"From Date","From Date"
+"To Date","To Date"

--- a/i18n/fr_FR.csv
+++ b/i18n/fr_FR.csv
@@ -25,3 +25,5 @@
 "Alternative text for this label","Texte alternatif du label"
 "All Store Views","Toutes les vues magasin"
 "Store View","Vue magasin"
+"From Date","De la date"
+"To Date","À la date"

--- a/view/adminhtml/ui_component/smile_productlabel_productlabel_form.xml
+++ b/view/adminhtml/ui_component/smile_productlabel_productlabel_form.xml
@@ -223,7 +223,43 @@
             </formElements>
         </field>
 
-        <field name="image" formElement="imageUploader" sortOrder="50">
+        <field name="from_date" formElement="date" sortOrder="50">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">from_date</item>
+                </item>
+            </argument>
+            <settings>
+                <validation>
+                    <rule name="validate-date" xsi:type="boolean">true</rule>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+                <dataType>text</dataType>
+                <label translate="true">Form Date</label>
+                <visible>true</visible>
+                <dataScope>from_date</dataScope>
+            </settings>
+        </field>
+
+        <field name="to_date" formElement="date" sortOrder="55">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">to_date</item>
+                </item>
+            </argument>
+            <settings>
+                <validation>
+                    <rule name="validate-date" xsi:type="boolean">true</rule>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
+                </validation>
+                <dataType>text</dataType>
+                <label translate="true">To Date</label>
+                <visible>true</visible>
+                <dataScope>to_date</dataScope>
+            </settings>
+        </field>
+
+        <field name="image" formElement="imageUploader" sortOrder="60">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">productlabel</item>
@@ -231,6 +267,7 @@
             </argument>
             <settings>
                 <validation>
+                    <rule name="required-entry" xsi:type="boolean">true</rule>
                     <rule name="required-entry" xsi:type="boolean">true</rule>
                 </validation>
                 <elementTmpl>ui/form/element/uploader/image</elementTmpl>
@@ -256,7 +293,7 @@
             </formElements>
         </field>
 
-        <field name="position_category_list" formElement="select" sortOrder="60">
+        <field name="position_category_list" formElement="select" sortOrder="70">
             <argument name="data" xsi:type="array">
                 <item name="options" xsi:type="object">Smile\ProductLabel\Ui\Component\Source\Location\Options</item>
                 <item name="config" xsi:type="array">
@@ -276,7 +313,7 @@
             </settings>
         </field>
 
-        <field name="position_product_view" formElement="select" sortOrder="70">
+        <field name="position_product_view" formElement="select" sortOrder="80">
             <argument name="data" xsi:type="array">
                 <item name="options" xsi:type="object">Smile\ProductLabel\Ui\Component\Source\Location\Options</item>
                 <item name="config" xsi:type="array">
@@ -296,7 +333,7 @@
             </settings>
         </field>
 
-        <field name="display_on" formElement="multiselect" sortOrder="80">
+        <field name="display_on" formElement="multiselect" sortOrder="90">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">productlabel</item>
@@ -320,7 +357,7 @@
             </formElements>
         </field>
 
-        <field name="alt" formElement="input" sortOrder="90">
+        <field name="alt" formElement="input" sortOrder="100">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">alt</item>

--- a/view/adminhtml/ui_component/smile_productlabel_productlabel_listing.xml
+++ b/view/adminhtml/ui_component/smile_productlabel_productlabel_listing.xml
@@ -177,7 +177,27 @@
             </settings>
         </column>
 
-        <column name="is_active" sortOrder="60" component="Magento_Ui/js/grid/columns/select">
+        <column name="from_date" sortOrder="60" class="Magento\Ui\Component\Listing\Columns\Date"
+                component="Magento_Ui/js/grid/columns/date">
+            <settings>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <dataType>date</dataType>
+                <label translate="true">From Date</label>
+            </settings>
+        </column>
+
+        <column name="to_date" sortOrder="65" class="Magento\Ui\Component\Listing\Columns\Date"
+                component="Magento_Ui/js/grid/columns/date">
+            <settings>
+                <filter>dateRange</filter>
+                <dataType>date</dataType>
+                <dataType>date</dataType>
+                <label translate="true">To Date</label>
+            </settings>
+        </column>
+
+        <column name="is_active" sortOrder="70" component="Magento_Ui/js/grid/columns/select">
             <settings>
                 <options>
                     <option name="active" xsi:type="array">
@@ -198,7 +218,7 @@
             </settings>
         </column>
 
-        <column name="store_id" class="Magento\Store\Ui\Component\Listing\Column\Store" sortOrder="65">
+        <column name="store_id" class="Magento\Store\Ui\Component\Listing\Column\Store" sortOrder="80">
             <settings>
                 <label translate="true">Store View</label>
                 <bodyTmpl>ui/grid/cells/html</bodyTmpl>
@@ -206,7 +226,7 @@
             </settings>
         </column>
 
-        <actionsColumn sortOrder="70" name="actions" class="Smile\ProductLabel\Ui\Component\Listing\Column\AttributeActions">
+        <actionsColumn sortOrder="90" name="actions" class="Smile\ProductLabel\Ui\Component\Listing\Column\AttributeActions">
             <settings>
                 <indexField>product_label_id</indexField>
             </settings>


### PR DESCRIPTION
Rebased version of #32 

> In this feature, we wanted to add the possibility of setting a begining date and ending date to show a product label.
> 
> To do so, we added two date fields in the database and did the same for the back office. We linked them together and added a simple condition in order to check if the product label should be shown in the storefront.
> 
> ![image](https://user-images.githubusercontent.com/59695834/94021064-e6b7cd00-fdb3-11ea-9a09-bc9ef98c8115.png) ![image](https://user-images.githubusercontent.com/59695834/94021268-1f57a680-fdb4-11ea-86ae-fd487d5a9f69.png)