### PR TITLE
Issue 57/fix m.2.4.5 p1 compatability

### DIFF
--- a/Model/ProductLabel.php
+++ b/Model/ProductLabel.php
@@ -117,11 +117,7 @@ class ProductLabel extends AbstractModel implements IdentityInterface, ProductLa
     {
         $stores = $this->hasData('stores') ? $this->getData('stores') : $this->getData('store_id');
 
-        if (is_numeric($stores)) {
-            $stores = [$stores];
-        }
-
-        return $stores ?? [];
+        return $stores ? array_map('intval', preg_split('/,/',$stores)) : [];
     }
 
     /**

--- a/Model/ResourceModel/ProductLabel.php
+++ b/Model/ResourceModel/ProductLabel.php
@@ -108,7 +108,7 @@ class ProductLabel extends AbstractDb
     {
         $oldStores = $this->getStoreIds($object);
         if (strpos($this->serializer->serialize($object->getStores()), ',') !== false) {
-            $newStores = explode(',', (string) $object->getStores());
+            $newStores = explode(',', implode(',', $object->getStores()));
         } else {
             $newStores = $object->getStores();
         }

--- a/view/adminhtml/ui_component/smile_productlabel_productlabel_listing.xml
+++ b/view/adminhtml/ui_component/smile_productlabel_productlabel_listing.xml
@@ -25,6 +25,7 @@
         <settings>
             <storageConfig>
                 <param name="indexField" xsi:type="string">id</param>
+                <param name="cacheRequests" xsi:type="boolean">false</param>
             </storageConfig>
             <updateUrl path="mui/index/render"/>
         </settings>


### PR DESCRIPTION
Adjustment to ui_component XML to disable caching preventing issue of duplicate records shown in admin grid (issue https://github.com/Smile-SA/magento2-module-product-label/issues/57 ).

Made some quick changes to the return value and type of two functions to match with the return type of the function to fix warnings when strict_type is enabled, feel free to finetune/adjust where necesarry. 