### PR TITLE
Fix API definition

### DIFF
--- a/Api/Data/ProductLabelInterface.php
+++ b/Api/Data/ProductLabelInterface.php
@@ -157,7 +157,7 @@ interface ProductLabelInterface
     /**
      * Get display_on
      *
-     * @return array
+     * @return int[]
      */
     public function getDisplayOn(): array;
 


### PR DESCRIPTION
Fix bug with API difinition : 
Message: The "array" class doesn't exist and the namespace must be specified. Verify and try again.