### PR TITLE
Support tablename with database prefix.

### DIFF
--- a/Setup/Patch/Data/UpdateExistingLabelsStoreView.php
+++ b/Setup/Patch/Data/UpdateExistingLabelsStoreView.php
@@ -31,7 +31,7 @@ class UpdateExistingLabelsStoreView implements DataPatchInterface
 
         $connection = $this->moduleDataSetup->getConnection();
         $select     = $connection->select()->from(
-            $connection->getTableName(ProductLabelInterface::TABLE_NAME),
+            $this->moduleDataSetup->getTable(ProductLabelInterface::TABLE_NAME),
             [
                 ProductLabelInterface::PRODUCTLABEL_ID => ProductLabelInterface::PRODUCTLABEL_ID,
                 new Zend_Db_Expr(Store::DEFAULT_STORE_ID . ' as ' . ProductLabelInterface::STORE_ID),
@@ -40,7 +40,7 @@ class UpdateExistingLabelsStoreView implements DataPatchInterface
 
         $data = $connection->fetchAll($select);
         $connection->insertOnDuplicate(
-            $connection->getTableName(ProductLabelInterface::STORE_TABLE_NAME),
+            $this->moduleDataSetup->getTable(ProductLabelInterface::STORE_TABLE_NAME),
             $data,
             [ProductLabelInterface::PRODUCTLABEL_ID, ProductLabelInterface::STORE_ID]
         );


### PR DESCRIPTION
To correctly retrieve the table name with the database prefix, the `getTable` method must be used. Otherwise, the prefix will be missing, causing an error during module installation that stops the process due to the inability to locate the table.